### PR TITLE
Added option to use floats in neighbors data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ implemented under `src/kilobot/behaviors` directly.
 
 The C source file should be placed inside `src/<robot_name>/behaviors`,
 whereas the Buzz script is expected to have the same name and be
-placer under `src/<robot_name>/behaviors/buzz_scripts`. You should also place a
+placed under `src/<robot_name>/behaviors/buzz_scripts`. You should also place a
 Buzz String Table (`.bst`) file (which allows BittyBuzz to generate a
 string ID corresponding to each string) next to your Buzz script, which
 should contain any string used within the C code and that does not appear
@@ -100,29 +100,30 @@ recommend against changing these values unless it is necessary.
 The table below describes all configurable values and classifies each one by
 the likelihood that one will require changing it.
 
-|          Option           |                        Description                        |          Adjustment likelihood           |  PC  | Kilobot |
-|---------------------------|-----------------------------------------------------------|:----------------------------------------:|:----:|:-------:|
-| `BBZHEAP_SIZE`            | Size of the heap (B)                                      | <span style="color:#800">High</span>     | 3264 | 1088    |
-| `BBZHEAP_ELEMS_PER_TSEG`  | Num. entries per table segment                            | <span style="color:#880">Moderate</span> | 5    | 5       |
-| `BBZSTACK_SIZE`           | Size of the stack (num. objects)                          | <span style="color:#800">High</span>     | 96   | 96      |
-| `BBZVSTIG_CAP`            | Capacity of the `stigmergy` structure (num. entries)      | <span style="color:#800">High</span>     | 3    | 3       |
-| `BBZNEIGHBORS_CAP`        | Capacity of the `neighbors` structure (num. neighbors)    | <span style="color:#080">Low</span>      | 15   | 15      |
-| `BBZINMSG_QUEUE_CAP`      | Capacity of the incoming message queue (num. msgs)        | <span style="color:#080">Low</span>      | 10   | 10      |
-| `BBZOUTMSG_QUEUE_CAP`     | Capacity of the outgoing message queue (num. msgs)        | <span style="color:#080">Low</span>      | 10   | 10      |
-| `BBZHEAP_RSV_ACTREC_MAX`  | Num. objects on the heap reserved for activation records  | <span style="color:#880">Moderate</span> | 28   | 28      |
-| `BBZLAMPORT_THRESHOLD`    | Length of Lamport clocks' accepting zone                  | <span style="color:#080">Low</span>      | 50   | 50      |
-| `BBZHEAP_GCMARK_DEPTH`    | Garbage collector max recursion depth                     | <span style="color:#080">Low</span>      | 8    | 8       |
-| `BBZMSG_IN_PROC_MAX`      | Max. num. of incoming messages processed per timestep     | <span style="color:#880">Moderate</span> | 10   | 10      |
-| `BBZNEIGHBORS_CLR_PERIOD` | Num. timesteps between neighbor clears                    | <span style="color:#080">Low</span>      | 10   | 10      |
-| `BBZNEIGHBORS_MARK_TIME`  | Num. timesteps before clear we spend marking neighbors    | <span style="color:#080">Low</span>      | 4    | 4       |
-| `BBZ_XTREME_MEMORY`       | Whether to reduce RAM at the cost of Flash                | <span style="color:#880">Moderate</span> | OFF  | ON      |
-| `BBZ_USE_PRIORITY_SORT`   | Whether to use priority sort on outgoing message queue    | <span style="color:#080">Low</span>      | OFF  | OFF     |
-| `BBZ_USE_FLOAT`           | Whether to use float type                                 | <span style="color:#080">Low</span>      | OFF  | OFF     |
-| `BBZ_DISABLE_NEIGHBORS`   | Whether to disable the `neighbors` structure              | <span style="color:#800">High</span>     | OFF  | OFF     |
-| `BBZ_DISABLE_VSTIGS`      | Whether to disable the `stigmergy` structure              | <span style="color:#800">High</span>     | OFF  | OFF     |
-| `BBZ_DISABLE_SWARMS`      | Whether to disable the `swarms` structure                 | <span style="color:#800">High</span>     | OFF  | OFF     |
-| `BBZ_DISABLE_MESSAGES`    | Whether to disable Buzz messages                          | <span style="color:#880">Moderate</span> | OFF  | OFF     |
-| `BBZ_DISABLE_PY_BEHAV`    | Whether to disable Python behaviors of closures           | <span style="color:#080">Low</span>      | OFF  | OFF     |
+|          Option            |                        Description                         |          Adjustment likelihood           |  PC  | Kilobot |
+|----------------------------|------------------------------------------------------------|:----------------------------------------:|:----:|:-------:|
+| `BBZHEAP_SIZE`             | Size of the heap (B)                                       | <span style="color:#800">High</span>     | 3264 | 1088    |
+| `BBZHEAP_ELEMS_PER_TSEG`   | Num. entries per table segment                             | <span style="color:#880">Moderate</span> | 5    | 5       |
+| `BBZSTACK_SIZE`            | Size of the stack (num. objects)                           | <span style="color:#800">High</span>     | 96   | 96      |
+| `BBZVSTIG_CAP`             | Capacity of the `stigmergy` structure (num. entries)       | <span style="color:#800">High</span>     | 3    | 3       |
+| `BBZNEIGHBORS_CAP`         | Capacity of the `neighbors` structure (num. neighbors)     | <span style="color:#080">Low</span>      | 15   | 15      |
+| `BBZINMSG_QUEUE_CAP`       | Capacity of the incoming message queue (num. msgs)         | <span style="color:#080">Low</span>      | 10   | 10      |
+| `BBZOUTMSG_QUEUE_CAP`      | Capacity of the outgoing message queue (num. msgs)         | <span style="color:#080">Low</span>      | 10   | 10      |
+| `BBZHEAP_RSV_ACTREC_MAX`   | Num. objects on the heap reserved for activation records   | <span style="color:#880">Moderate</span> | 28   | 28      |
+| `BBZLAMPORT_THRESHOLD`     | Length of Lamport clocks' accepting zone                   | <span style="color:#080">Low</span>      | 50   | 50      |
+| `BBZHEAP_GCMARK_DEPTH`     | Garbage collector max recursion depth                      | <span style="color:#080">Low</span>      | 8    | 8       |
+| `BBZMSG_IN_PROC_MAX`       | Max. num. of incoming messages processed per timestep      | <span style="color:#880">Moderate</span> | 10   | 10      |
+| `BBZNEIGHBORS_CLR_PERIOD`  | Num. timesteps between neighbor clears                     | <span style="color:#080">Low</span>      | 10   | 10      |
+| `BBZNEIGHBORS_MARK_TIME`   | Num. timesteps before clear we spend marking neighbors     | <span style="color:#080">Low</span>      | 4    | 4       |
+| `BBZ_XTREME_MEMORY`        | Whether to reduce RAM at the cost of Flash                 | <span style="color:#880">Moderate</span> | OFF  | ON      |
+| `BBZ_USE_PRIORITY_SORT`    | Whether to use priority sort on outgoing message queue     | <span style="color:#080">Low</span>      | OFF  | OFF     |
+| `BBZ_USE_FLOAT`            | Whether to use float type                                  | <span style="color:#080">Low</span>      | OFF  | OFF     |
+| `BBZ_DISABLE_NEIGHBORS`    | Whether to disable the `neighbors` structure               | <span style="color:#800">High</span>     | OFF  | OFF     |
+| `BBZ_DISABLE_VSTIGS`       | Whether to disable the `stigmergy` structure               | <span style="color:#800">High</span>     | OFF  | OFF     |
+| `BBZ_DISABLE_SWARMS`       | Whether to disable the `swarms` structure                  | <span style="color:#800">High</span>     | OFF  | OFF     |
+| `BBZ_DISABLE_MESSAGES`     | Whether to disable Buzz messages                           | <span style="color:#880">Moderate</span> | OFF  | OFF     |
+| `BBZ_DISABLE_PY_BEHAV`     | Whether to disable Python behaviors of closures            | <span style="color:#080">Low</span>      | OFF  | OFF     |
+| `BBZ_NEIGHBORS_USE_FLOATS` | Whether to use floats for the neighbor's range and bearing | <span style="color:#880">Moderate</span> | ON   | OFF     |
 
 For example, for a Buzz program requiring larger stack sizes but less heap allocations, you may run cmake as:
 

--- a/src/bittybuzz/bbzneighbors.c
+++ b/src/bittybuzz/bbzneighbors.c
@@ -19,12 +19,21 @@
  */
 static void push_neighbor_data_table(const bbzneighbors_elem_t* elem) {
     bbzvm_pusht();
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     // Distance
     bbztable_add_data(__BBZSTRID_distance,  bbzint_new(elem->distance));
     // Azimuth
     bbztable_add_data(__BBZSTRID_azimuth,   bbzint_new(elem->azimuth));
     // Elevation
     bbztable_add_data(__BBZSTRID_elevation, bbzint_new(elem->elevation));
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    // Distance
+    bbztable_add_data(__BBZSTRID_distance,  bbzfloat_new(elem->distance));
+    // Azimuth
+    bbztable_add_data(__BBZSTRID_azimuth,   bbzfloat_new(elem->azimuth));
+    // Elevation
+    bbztable_add_data(__BBZSTRID_elevation, bbzfloat_new(elem->elevation));
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
 }
 
 /**

--- a/src/bittybuzz/bbzneighbors.h
+++ b/src/bittybuzz/bbzneighbors.h
@@ -93,9 +93,15 @@ extern "C" {
 typedef struct PACKED bbzneighbors_elem_t {
 #ifndef BBZ_DISABLE_NEIGHBORS
     bbzrobot_id_t robot;    /**< @brief ID of the robot this entry is for. */
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     uint8_t distance;       /**< @brief Distance between to the given robot. */
     uint8_t azimuth;        /**< @brief Angle (in rad) on the XY plane. */
     uint8_t elevation;      /**< @brief Angle (in rad) between the XY plane and the robot. */
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzfloat distance;      /**< @brief Distance between to the given robot. */
+    bbzfloat azimuth;       /**< @brief Angle (in rad) on the XY plane. */
+    bbzfloat elevation;     /**< @brief Angle (in rad) between the XY plane and the robot. */
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
     uint8_t mdata;          /**< @brief Neighbor element metadata @details 7th bit: neighbors data GC marking flag */
 #endif // !BBZ_DISABLE_NEIGHBORS
 } bbzneighbors_elem_t;

--- a/src/bittybuzz/config.h.in
+++ b/src/bittybuzz/config.h.in
@@ -137,4 +137,10 @@
  */
 #cmakedefine BBZ_BYTEWISE_ASSIGNMENT
 
+/**
+ * @brief Whether to use floats for the neighbor's range and bearing
+ * measurments.
+ */
+#cmakedefine BBZ_NEIGHBORS_USE_FLOATS
+
 #endif // !CONFIG_H

--- a/src/cmake/BittyBuzzConfig.cmake
+++ b/src/cmake/BittyBuzzConfig.cmake
@@ -33,6 +33,7 @@ option(BBZ_DISABLE_SWARMS "Whether to disable usage of swarms' data structure an
 option(BBZ_DISABLE_MESSAGES "Whether to disable usage and transfer of any kind of Buzz message." OFF)
 option(BBZ_DISABLE_PY_BEHAV "Whether to disable Python behaviors of closures (make closure behave like in JavaScript)." OFF)
 option(BBZ_BYTEWISE_ASSIGNMENT "Wether to make assignment byte per byte." OFF)
+option(BBZ_NEIGHBORS_USE_FLOATS "Whether to use floats for the neighbor's range and bearing measurments." ON)
 
 # TODO Currently, there is no implementation of swarmlist broadcasts because
 # neighbors.kin and neighbors.nonkin, which are the only closures that would

--- a/src/cmake/Kilobot.cmake
+++ b/src/cmake/Kilobot.cmake
@@ -48,6 +48,7 @@ set(CURRENT_COMPILER "NATIVE" CACHE STRING "Which compiler we are using.")
 #
 set(BBZ_ROBOT kilobot)
 option(BBZ_XTREME_MEMORY "Whether to enable high memory-optimization." ON)
+option(BBZ_NEIGHBORS_USE_FLOATS "Whether to use floats for the neighbor's range and bearing measurments." OFF)
 
 #
 # CMake command to compile an executable

--- a/src/crazyflie/lib/inc/bbzcrazyflie.h
+++ b/src/crazyflie/lib/inc/bbzcrazyflie.h
@@ -30,7 +30,7 @@ extern "C" {
 /* Exported constants --------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
-typedef void (*message_rx_t)(Message *, uint16_t distance, int16_t azimuth);
+typedef void (*message_rx_t)(Message *, float distance, float azimuth);
 typedef Message *(*message_tx_t)(void);
 typedef void (*message_tx_success_t)(void);
 

--- a/src/crazyflie/lib/src/bbzcrazyflie.c
+++ b/src/crazyflie/lib/src/bbzcrazyflie.c
@@ -151,7 +151,7 @@ Message* bbzwhich_msg_tx() {
     return 0;
 }
 
-void bbzprocess_msg_rx(Message* msg_rx, uint16_t distance, int16_t azimuth) {
+void bbzprocess_msg_rx(Message* msg_rx, float distance, float azimuth) {
 #ifndef BBZ_DISABLE_MESSAGES
     if (msg_rx->header.type == TYPE_BBZ_MESSAGE) {
         bbzringbuf_clear(&bbz_payload_buf);
@@ -162,10 +162,16 @@ void bbzprocess_msg_rx(Message* msg_rx, uint16_t distance, int16_t azimuth) {
 #ifndef BBZ_DISABLE_NEIGHBORS
         if (*bbzmsg_buf == BBZMSG_BROADCAST) {
             bbzneighbors_elem_t elem;
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
             elem.azimuth = azimuth;
             elem.elevation = 0;
-            elem.robot = *(uint8_t*)msg_rx->payload;
             elem.distance = distance << 1;
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+            elem.azimuth = bbzfloat_fromfloat(azimuth);
+            elem.elevation = bbzfloat_fromfloat(0.f);
+            elem.distance = bbzfloat_fromfloat(distance);
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+            elem.robot = *(uint8_t*)msg_rx->payload;
             bbzneighbors_add(&elem);
         }
 #endif // !BBZ_DISABLE_NEIGHBORS

--- a/src/kilobot/lib/bbzkilobot.c
+++ b/src/kilobot/lib/bbzkilobot.c
@@ -181,9 +181,14 @@ void bbzprocess_msg_rx(message_t* msg_rx, distance_measurement_t* d) {
         if (*bbzmsg_buf == BBZMSG_BROADCAST) {
             uint8_t dist = ((uint8_t)(d->high_gain>>2) + (uint8_t)(d->low_gain>>2))>>1;
             bbzneighbors_elem_t elem = {.azimuth=0,.elevation=0};
+            uint8_t distance = (kilo_irhigh + kilo_irlow) >> 1;
+            distance -= (dist>distance?distance:dist);
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
+            elem.distance -= distance;
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+            elem.distance -= bbzfloat_fromint(distance);
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
             elem.robot = *(uint16_t*)(bbzmsg_buf + 1);
-            elem.distance = (kilo_irhigh + kilo_irlow) >> 1;
-            elem.distance -= (dist>elem.distance?elem.distance:dist);
             bbzneighbors_add(&elem);
         }
 #endif // !BBZ_DISABLE_NEIGHBORS

--- a/src/testing/testneighbors.c
+++ b/src/testing/testneighbors.c
@@ -10,7 +10,11 @@ TEST(nadd) {
     vm = &vmObj;
     bbzvm_construct(0);
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem = {.robot=1,.distance=127,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem = {.robot=1,.distance=bbzfloat_fromint(127),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_add(&elem);
     REQUIRE(vm->state != BBZVM_STATE_ERROR);
 #ifndef BBZ_XTREME_MEMORY
@@ -95,7 +99,11 @@ TEST(ignore) {
 TEST(get) {
     bbzvm_construct(0);
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem = {.robot=1,.distance=127,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem = {.robot=1,.distance=bbzfloat_fromint(127),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_add(&elem);
 
     bbzvm_push(vm->neighbors.hpos);
@@ -114,7 +122,27 @@ TEST(get) {
 void foreach_fun() {
     bbzvm_assert_lnum(2);
 
-    // TODO
+    bbzvm_assert_type(bbzvm_locals_at(1), BBZTYPE_INT);
+    bbzvm_assert_type(bbzvm_locals_at(2), BBZTYPE_TABLE);
+    bbzheap_idx_t dist_idx;
+    if (bbztable_get(bbzvm_locals_at(2), bbzstring_get(__BBZSTRID_distance), &dist_idx)) {
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
+        bbzvm_assert_type(dist_idx, BBZTYPE_INT);
+        bbzvm_assert_exec(bbzheap_obj_at(dist_idx)->i.value > 0)
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+        bbzvm_assert_type(dist_idx, BBZTYPE_FLOAT);
+        bbzvm_assert_exec(bbzfloat_tofloat(bbzheap_obj_at(dist_idx)->f.value) > 0.f, BBZVM_ERROR_MATH);
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+    }
+    if (bbztable_get(bbzvm_locals_at(2), bbzstring_get(__BBZSTRID_azimuth), &dist_idx)) {
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
+        bbzvm_assert_type(dist_idx, BBZTYPE_INT);
+        bbzvm_assert_exec(bbzheap_obj_at(dist_idx)->i.value == 0)
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+        bbzvm_assert_type(dist_idx, BBZTYPE_FLOAT);
+        bbzvm_assert_exec(bbzfloat_tofloat(bbzheap_obj_at(dist_idx)->f.value) == 0.f, BBZVM_ERROR_MATH);
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+    }
 
     bbzvm_ret0();
 }
@@ -122,9 +150,14 @@ void foreach_fun() {
 TEST(foreach) {
     bbzvm_construct(0);
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem = {.robot=1,.distance=127,.azimuth=0,.elevation=0};
-    bbzneighbors_add(&elem);
     bbzneighbors_elem_t elem2 = {.robot=2,.distance=64,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem = {.robot=1,.distance=bbzfloat_fromint(127),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+    bbzneighbors_elem_t elem2 = {.robot=2,.distance=bbzfloat_fromint(64),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_add(&elem);
     bbzneighbors_add(&elem2);
 
     bbzvm_push(vm->neighbors.hpos);
@@ -151,9 +184,14 @@ void map_fun() {
 TEST(map) {
     bbzvm_construct(0);
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem = {.robot=1,.distance=127,.azimuth=0,.elevation=0};
-    bbzneighbors_add(&elem);
     bbzneighbors_elem_t elem2 = {.robot=2,.distance=64,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem = {.robot=1,.distance=bbzfloat_fromint(127),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+    bbzneighbors_elem_t elem2 = {.robot=2,.distance=bbzfloat_fromint(64),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_add(&elem);
     bbzneighbors_add(&elem2);
 
     bbzvm_push(vm->neighbors.hpos);
@@ -180,9 +218,14 @@ void reduce_fun() {
 TEST(reduce) {
     bbzvm_construct(0);
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem = {.robot=1,.distance=127,.azimuth=0,.elevation=0};
-    bbzneighbors_add(&elem);
     bbzneighbors_elem_t elem2 = {.robot=2,.distance=64,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem = {.robot=1,.distance=bbzfloat_fromint(127),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+    bbzneighbors_elem_t elem2 = {.robot=2,.distance=bbzfloat_fromint(64),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_add(&elem);
     bbzneighbors_add(&elem2);
 
     bbzvm_push(vm->neighbors.hpos);
@@ -212,9 +255,14 @@ void filter_fun() {
 TEST(filter) {
     bbzvm_construct(0);
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem = {.robot=1,.distance=127,.azimuth=0,.elevation=0};
-    bbzneighbors_add(&elem);
     bbzneighbors_elem_t elem2 = {.robot=2,.distance=64,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem = {.robot=1,.distance=bbzfloat_fromint(127),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+    bbzneighbors_elem_t elem2 = {.robot=2,.distance=bbzfloat_fromint(64),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_add(&elem);
     bbzneighbors_add(&elem2);
 
     bbzvm_push(vm->neighbors.hpos);
@@ -232,9 +280,14 @@ TEST(filter) {
 TEST(count) {
     bbzvm_construct(0);
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem = {.robot=1,.distance=127,.azimuth=0,.elevation=0};
-    bbzneighbors_add(&elem);
     bbzneighbors_elem_t elem2 = {.robot=2,.distance=64,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem = {.robot=1,.distance=bbzfloat_fromint(127),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+    bbzneighbors_elem_t elem2 = {.robot=2,.distance=bbzfloat_fromint(64),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_add(&elem);
     bbzneighbors_add(&elem2);
 
     bbzvm_push(vm->neighbors.hpos);
@@ -258,15 +311,24 @@ TEST(count) {
 TEST(data_gc) {
     bbzvm_construct(0);
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem2 = {.robot=2,.distance=64,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem2 = {.robot=2,.distance=bbzfloat_fromint(64),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_add(&elem2);
     REQUIRE(data_gc_count == 1);
 
     vm->neighbors.clear_counter = BBZNEIGHBORS_MARK_TIME-1;
 
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
     bbzneighbors_elem_t elem = {.robot=1,.distance=127,.azimuth=0,.elevation=0};
-    bbzneighbors_add(&elem);
     bbzneighbors_elem_t elem3 = {.robot=3,.distance=100,.azimuth=0,.elevation=0};
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_elem_t elem = {.robot=1,.distance=bbzfloat_fromint(127),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+    bbzneighbors_elem_t elem3 = {.robot=3,.distance=bbzfloat_fromint(100),.azimuth=bbzfloat_fromint(0),.elevation=bbzfloat_fromint(0)};
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+    bbzneighbors_add(&elem);
     bbzneighbors_add(&elem3);
     REQUIRE(data_gc_count == 3);
 

--- a/src/zooids/lib/inc/functions.h
+++ b/src/zooids/lib/inc/functions.h
@@ -19,7 +19,7 @@
 #include "memcpy_fast.h"
 #include "qfplib.h"
 
-typedef void (*message_rx_t)(Message *, uint16_t distance, int16_t azimuth);
+typedef void (*message_rx_t)(Message *, float distance, float azimuth);
 typedef Message *(*message_tx_t)(void);
 typedef void (*message_tx_success_t)(void);
 

--- a/src/zooids/lib/src/bbzzooids.c
+++ b/src/zooids/lib/src/bbzzooids.c
@@ -93,7 +93,7 @@ Message* bbzwhich_msg_tx() {
     return 0;
 }
 
-void bbzprocess_msg_rx(Message* msg_rx, uint16_t distance, int16_t azimuth) {
+void bbzprocess_msg_rx(Message* msg_rx, float distance, float azimuth) {
 #ifndef BBZ_DISABLE_MESSAGES
     if (msg_rx->header.type == TYPE_BBZ_MESSAGE) {
         bbzringbuf_clear(&bbz_payload_buf);
@@ -104,10 +104,16 @@ void bbzprocess_msg_rx(Message* msg_rx, uint16_t distance, int16_t azimuth) {
 #ifndef BBZ_DISABLE_NEIGHBORS
         if (*bbzmsg_buf == BBZMSG_BROADCAST) {
             bbzneighbors_elem_t elem;
+#ifndef BBZ_NEIGHBORS_USE_FLOATS
             elem.azimuth = azimuth;
             elem.elevation = 0;
-            elem.robot = *(uint8_t*)msg_rx->payload;
             elem.distance = distance << 1;
+#else // !BBZ_NEIGHBORS_USE_FLOATS
+            elem.azimuth = bbzfloat_fromfloat(azimuth);
+            elem.elevation = bbzfloat_fromint(0);
+            elem.distance = bbzfloat_fromfloat(distance);
+#endif // !BBZ_NEIGHBORS_USE_FLOATS
+            elem.robot = *(uint8_t*)msg_rx->payload;
             bbzneighbors_add(&elem);
         }
 #endif // !BBZ_DISABLE_NEIGHBORS

--- a/src/zooids/lib/src/functions.c
+++ b/src/zooids/lib/src/functions.c
@@ -198,9 +198,9 @@ void handleIncomingRadioMessage() {
       if (message_rx != NULL) {
         Position* rbtp = getRobotPosition();
         memcpy_fast(&msgp, msg.payload+1, sizeof(Position));
-        int16_t dist = qfp_float2uint(qfp_fsqrt(qfp_uint2float((uint32_t)(msgp.x - rbtp->x)*(uint32_t)(msgp.x - rbtp->x) + (uint32_t)(msgp.y - rbtp->y)*(uint32_t)(msgp.y - rbtp->y))));
-        int16_t azimuth = qfp_float2int(qfp_fmul(qfp_fatan2(qfp_int2float(msgp.y - rbtp->y), qfp_int2float(msgp.x - rbtp->x)), 180.0f / PI));
-        message_rx(&msg, CLAMP(dist, 0, 127), azimuth);
+        float dist = qfp_fsqrt(qfp_uint2float((uint32_t)(msgp.x - rbtp->x)*(uint32_t)(msgp.x - rbtp->x) + (uint32_t)(msgp.y - rbtp->y)*(uint32_t)(msgp.y - rbtp->y)));
+        float azimuth = qfp_fatan2(qfp_int2float(msgp.y - rbtp->y), qfp_int2float(msgp.x - rbtp->x));
+        message_rx(&msg, dist, azimuth);
       }
       break;
     case TYPE_REBOOT_ROBOT:


### PR DESCRIPTION
This adds the option to use floats for neighbors range and bearing measurements.

This is not tested on actual hardware, but everything compiles fine and the tests pass.

See Issue #9