### PR TITLE
Fix/lamport check and append circular buff in stigmergy

### DIFF
--- a/src/bittybuzz/bbzmsg.c
+++ b/src/bittybuzz/bbzmsg.c
@@ -110,7 +110,7 @@ static uint8_t bbzlamport_isnewer(bbzlamport_t lamport, bbzlamport_t old_lamport
     // This function uses a circular Lamport model (0 == 255 + 1).
     // A Lamport clock is 'newer' than an old Lamport clock if its value
     // is less than 'LAMPORT_THRESHOLD' ticks ahead of the old clock.
-    return (uint8_t)(((lamport - old_lamport) & 0xFF) < BBZLAMPORT_THRESHOLD);/**/
+    return (uint8_t)(lamport != old_lamport && ((lamport - old_lamport) & 0xFF) < BBZLAMPORT_THRESHOLD);/**/
 }
 void bbzmsg_process_vstig(bbzmsg_t* msg) {
     // Search the key in the vstig

--- a/src/bittybuzz/bbzoutmsg.c
+++ b/src/bittybuzz/bbzoutmsg.c
@@ -26,7 +26,7 @@ uint16_t bbzoutmsg_queue_size() {
 /****************************************/
 
 static bbzmsg_t* outmsg_queue_append_template() {
-    bbzmsg_t* m = ((bbzmsg_t*)bbzringbuf_at(&vm->outmsgs.queue, vm->outmsgs.queue.dataend + vm->outmsgs.queue.capacity));
+    bbzmsg_t* m = ((bbzmsg_t*)bbzringbuf_rawat(&vm->outmsgs.queue, vm->outmsgs.queue.dataend));
     if (bbzringbuf_full(&vm->outmsgs.queue)) {
         // If full, replace the message with the lowest priority (the last of the queue) with the new one.
         *((bbzmsg_t*)bbzringbuf_rawat(&vm->outmsgs.queue, vm->outmsgs.queue.dataend - (uint8_t)1 + vm->outmsgs.queue.capacity)) = *m;


### PR DESCRIPTION
This fixes  this [issue](https://github.com/MISTLab/BittyBuzz/issues/13), you can check it for more information.

When checked if a lamport is newer, if the lamports are equals, false is returned. This avoids always sending the same message back and forth between two hosts.

Also to add an item in the end, it's possible to use `bbzringbuf_rawat` instead. As of it's done now, when vm->outmsgs.queue.datastart is non zero, the value is written at the wrong index.
