### PR TITLE
Feat/add table functions

### DIFF
--- a/src/bittybuzz/bbzneighbors.c
+++ b/src/bittybuzz/bbzneighbors.c
@@ -207,6 +207,7 @@ static void neighbor_foreach_fun(bbzheap_idx_t key,
 
     // Call closure
     bbzvm_closure_call(2);
+    bbzvm_pop();
 
     // Garbage-collect to reduce memory usage.
     bbzvm_gc();

--- a/src/bittybuzz/bbztable.c
+++ b/src/bittybuzz/bbztable.c
@@ -212,7 +212,6 @@ static void table_foreach_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* pa
     bbzvm_closure_call(2);
 
     // Make sure we don't return a value in the foreach function.
-    bbzvm_assert_state();
     bbzvm_assert_exec(bbzvm_stack_size() > ss, BBZVM_ERROR_RET);
     bbzvm_pop(); // Pop self table
 }
@@ -256,7 +255,7 @@ typedef struct PACKED table_map_base_t {
 } table_map_base_t;
 
 static void table_map_base_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* params){
-    table_map_base_t* tm = (table_map_base_t*)params;
+    table_map_base_t* tm = params;
 
     // Save stack size
     uint16_t ss = bbzvm_stack_size();
@@ -334,7 +333,7 @@ typedef struct PACKED table_reduce_entry_t {
 } table_reduce_entry_t;
 
 static void table_reduce_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* params) {
-    table_reduce_entry_t* tr = (table_reduce_entry_t*)params;
+    table_reduce_entry_t* tr = params;
 
     // Save stack size
     uint16_t ss = bbzvm_stack_size();

--- a/src/bittybuzz/bbztable.c
+++ b/src/bittybuzz/bbztable.c
@@ -203,7 +203,7 @@ static void table_foreach_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* pa
     uint16_t ss = bbzvm_stack_size();
 
     /* Push self table, closure and params (key and value) */
-    bbzvm_lload(1); // Push self table
+    bbzvm_lload(1); // Push table
     bbzvm_push(*closure);
     bbzvm_push(key);
     bbzvm_push(value);
@@ -213,7 +213,7 @@ static void table_foreach_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* pa
 
     // Make sure we don't return a value in the foreach function.
     bbzvm_assert_exec(bbzvm_stack_size() > ss, BBZVM_ERROR_RET);
-    bbzvm_pop(); // Pop self table
+    bbzvm_pop(); // Pop the nil returned value
 }
 
 static void table_foreach() {
@@ -261,7 +261,7 @@ static void table_map_base_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* p
     uint16_t ss = bbzvm_stack_size();
 
     // Call closure
-    bbzvm_lload(1); // Push self table
+    bbzvm_lload(1); // Push table
     bbzvm_push(tm->c);
     bbzvm_push(key);
     bbzvm_push(value);
@@ -270,7 +270,7 @@ static void table_map_base_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* p
     // Make sure we returned a value, and get the value.
     bbzvm_assert_exec(bbzvm_stack_size() > ss, BBZVM_ERROR_RET);
     bbzheap_idx_t ret = bbzvm_stack_at(0);
-    bbzvm_pop(); // Pop return value
+    bbzvm_pop(); // Pop returned value
 
     // Add a value to return table.
     tm->set_elem(tm->t, key, value, ret);
@@ -351,7 +351,7 @@ static void table_reduce_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* par
 
     // Remove the return value and assign the accumulator the new value
     bbzheap_idx_t ret = bbzvm_stack_at(0);
-    bbzvm_pop(); // Pop return value
+    bbzvm_pop(); // Pop returned value
     tr->accum = ret;
 }
 

--- a/src/bittybuzz/bbztable.c
+++ b/src/bittybuzz/bbztable.c
@@ -4,6 +4,48 @@
 /****************************************/
 /****************************************/
 
+void buzzobj_foreach_entry(const void* key, void* data, void* params) {
+    /* Cast params */
+    struct buzzobj_foreach_params* p = (struct buzzobj_foreach_params*)params;
+    if(p->vm->state != BUZZVM_STATE_READY) return;
+    /* Push closure and params (key and value) */
+    buzzvm_push(p->vm, p->fun);
+    buzzvm_push(p->vm, *(buzzobj_t*)key);
+    buzzvm_push(p->vm, *(buzzobj_t*)data);
+    /* Call closure */
+    p->vm->state = buzzvm_closure_call(p->vm, 2);
+    if(p->vm->state != BUZZVM_STATE_READY) return;
+    /* Get rid of return value */
+    buzzvm_pop(p->vm);
+}
+
+void bbztable_register() {
+    bbztable_add_function(__BBZSTRID_foreach, bbztable_foreach);
+    bbztable_add_function(__BBZSTRID_filter,  bbztable_filter);
+    bbztable_add_function(__BBZSTRID_map,     bbztable_map);
+    bbztable_add_function(__BBZSTRID_get,     bbztable_get);
+    bbztable_add_function(__BBZSTRID_reduce,  bbztable_reduce);
+    bbztable_add_function(__BBZSTRID_size,    bbztable_size);
+}
+
+void bbzneighbors_foreach() {
+    bbzvm_assert_lnum(2);
+
+    // Get table
+    bbzheap_idx_t t = bbzvm_locals_at(1);
+    bbzvm_assert_type(t, BBZTYPE_TABLE);
+
+    // Get closure
+    bbzheap_idx_t c = bbzvm_locals_at(2);
+    bbzvm_assert_type(c, BBZTYPE_CLOSURE);
+
+    // Perform foreach
+    bbztable_foreach(t, &c, NULL);
+
+    bbzvm_ret0();
+}
+
+
 uint8_t bbztable_get(bbzheap_idx_t t,
                      bbzheap_idx_t k,
                      bbzheap_idx_t* v) {

--- a/src/bittybuzz/bbztable.c
+++ b/src/bittybuzz/bbztable.c
@@ -196,14 +196,16 @@ void table_foreach_entry(bbzheap_idx_t key, bbzheap_idx_t value, void* params) {
     /* Cast params */
     bbzheap_idx_t* closure = params;
 
-    /* Push closure and params (key and value) */
-    bbzvm_push(closure);
+    /* Push self table, closure and params (key and value) */
+    bbzvm_lload(1); // Push self table
+    bbzvm_push(*closure);
     bbzvm_push(key);
     bbzvm_push(value);
 
     /* Call closure */
     bbzvm_closure_call(2);
     bbzvm_assert_state();
+    bbzvm_pop(); // Pop self table
 }
 
 void table_foreach() {
@@ -224,11 +226,11 @@ void table_foreach() {
 }
 
 void bbztable_register() {
-    bbztable_add_function(__BBZSTRID_foreach, table_foreach);
+    bbzvm_function_register(__BBZSTRID_foreach, table_foreach);
     /*
-    bbztable_add_function(__BBZSTRID_filter,  bbztable_filter);
-    bbztable_add_function(__BBZSTRID_map,     bbztable_map);
-    bbztable_add_function(__BBZSTRID_get,     bbztable_get);
-    bbztable_add_function(__BBZSTRID_reduce,  bbztable_reduce);
-    bbztable_add_function(__BBZSTRID_size,    bbztable_size);*/
+    bbzvm_function_register(__BBZSTRID_filter,  bbztable_filter);
+    bbzvm_function_register(__BBZSTRID_map,     bbztable_map);
+    bbzvm_function_register(__BBZSTRID_get,     bbztable_get);
+    bbzvm_function_register(__BBZSTRID_reduce,  bbztable_reduce);
+    bbzvm_function_register(__BBZSTRID_size,    bbztable_size);*/
 }

--- a/src/bittybuzz/bbztable.c
+++ b/src/bittybuzz/bbztable.c
@@ -3,6 +3,7 @@
 
 /****************************************/
 /****************************************/
+
 uint8_t bbztable_get(bbzheap_idx_t t,
                      bbzheap_idx_t k,
                      bbzheap_idx_t* v) {

--- a/src/bittybuzz/bbztable.h
+++ b/src/bittybuzz/bbztable.h
@@ -14,6 +14,12 @@
 extern "C" {
 #endif // __cplusplus
 
+
+/**
+ * @brief Registers and constructs the VM's table functions.
+ */
+void bbztable_register();
+
 /**
  * @brief Pointer to an element-wise function.
  * @details This function pointer is used in algorithms such as

--- a/src/bittybuzz/bbzvm.c
+++ b/src/bittybuzz/bbzvm.c
@@ -136,6 +136,7 @@ void bbzvm_construct(bbzrobot_id_t robot) {
     bbzvstig_register();
     bbzswarm_register();
     bbzneighbors_register();
+    bbztable_register();
     
 }
 


### PR DESCRIPTION
Added global functions for tables manipulation to solve #21. Can now use size, foreach, filter, map and reduce function, matching the [Buzz API](https://github.com/buzz-lang/Buzz/blob/master/doc/api.md#tables). 

While it's similar to what was done in the neighors functions, instead of pushing the table/accumulator value to the stack and then fetching it, I pass the heap value via the params void pointer.

Comments are more than welcomed.