### PR TITLE
Now passing subtable to neighbors map

### DIFF
--- a/src/bittybuzz/bbzneighbors.c
+++ b/src/bittybuzz/bbzneighbors.c
@@ -280,7 +280,10 @@ static void neighbor_map_base(bbzheap_idx_t key,
     bbzvm_pop();
 
     // Add a value to return table.
-    bbzvm_push(nm->t);
+    bbzheap_idx_t sub_tbl = vm->nil;;
+    bbztable_get(nm->t, bbzstring_get(INTERNAL_STRID_SUB_TBL), &sub_tbl);
+    bbzvm_assert_type(sub_tbl, BBZTYPE_TABLE);
+    bbzvm_push(sub_tbl); // push the subtable
     bbzvm_pushi(key);
     nm->put_elem(value, ret);
 


### PR DESCRIPTION
The whole neighbors table was passed to the foreach instead of the subtable in the `neighbor_map_base` function. This fixes #25.