### PR TITLE
Use cmakedefine instead of add definition

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,10 +22,6 @@ link_directories(${CMAKE_BINARY_DIR}/bittybuzz)
 #
 include(${INCLUDE_FILES_CMAKE}/BittyBuzzConfig.cmake)
 
-if (BBZ_USE_FLOAT)
-    add_definitions(-DBBZ_USE_FLOAT=1)
-endif (BBZ_USE_FLOAT)
-
 #
 # Host compiler values
 #

--- a/src/bittybuzz/config.h.in
+++ b/src/bittybuzz/config.h.in
@@ -138,6 +138,11 @@
 #cmakedefine BBZ_BYTEWISE_ASSIGNMENT
 
 /**
+ * @brief Whether to floats
+ */
+#cmakedefine BBZ_USE_FLOAT
+
+/**
  * @brief Whether to use floats for the neighbor's range and bearing
  * measurments.
  */


### PR DESCRIPTION
The define used [here](https://github.com/buzz-lang/BittyBuzz/blob/d093626cc4597ece927cd1dcdcfbea227f51643d/src/bittybuzz/bbztype.c#L21) was not enabled even when BBZ_USE_FLOAT was set to ON because it's not a define.